### PR TITLE
fix build on openwrt - unknown type name 'pid_t'

### DIFF
--- a/process.h
+++ b/process.h
@@ -1,5 +1,6 @@
 #ifndef NLTRACE_PROCESS_H
 #define NLTRACE_PROCESS_H
+#include <sys/types.h>
 
 struct process;
 struct descriptor;


### PR DESCRIPTION
without this fix, building on openwrt leads to:

```
make[5]: Entering directory '/home/christof/gluon/lede/build_dir/target-x86_64_musl-1.1.16/nltrace-2018-03-10-59dac1af'
x86_64-openwrt-linux-musl-gcc -Os -pipe -g3 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -iremap/home/christof/gluon/lede/build_dir/target-x86_64_musl-1.1.16/nltrace-2018-03-10-59dac1af:nltrace-2018-03-10-59dac1af -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro  -I/home/christof/gluon/lede/staging_dir/target-x86_64_musl-1.1.16/usr/include -I/home/christof/gluon/lede/staging_dir/target-x86_64_musl-1.1.16/include -I/home/christof/gluon/lede/staging_dir/toolchain-x86_64_gcc-5.4.0_musl-1.1.16/usr/include -I/home/christof/gluon/lede/staging_dir/toolchain-x86_64_gcc-5.4.0_musl-1.1.16/include/fortify -I/home/christof/gluon/lede/staging_dir/toolchain-x86_64_gcc-5.4.0_musl-1.1.16/include  -D_GNU_SOURCE -Wall -Wextra -I/usr/include/libnl3 -g -fPIC -c tracer.c -o tracer.o
In file included from tracer.c:6:0:
process.h:8:32: error: unknown type name 'pid_t'
 struct process *process_alloc (pid_t pid);
                                ^
Makefile:13: recipe for target 'tracer.o' failed
make[5]: *** [tracer.o] Error 1
make[5]: Leaving directory '/home/christof/gluon/lede/build_dir/target-x86_64_musl-1.1.16/nltrace-2018-03-10-59dac1af'
Makefile:27: recipe for target '/home/christof/gluon/lede/build_dir/target-x86_64_musl-1.1.16/nltrace-2018-03-10-59dac1af/.built' failed
make[4]: *** [/home/christof/gluon/lede/build_dir/target-x86_64_musl-1.1.16/nltrace-2018-03-10-59dac1af/.built] Error 2
make[4]: Leaving directory '/home/christof/gluon/package/nltrace'
package/Makefile:105: recipe for target 'package/feeds/gluon/nltrace/compile' failed
make[3]: *** [package/feeds/gluon/nltrace/compile] Error 2
```